### PR TITLE
fix: copy webpack config override file in builder image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,19 @@
-# Get nodejs last image
 FROM node:lts as prod
 ARG REACT_APP_BACKEND_URL
+
 COPY src /app/src
 COPY public /app/public
 COPY package.json /app
 COPY package-lock.json /app
 COPY .prettierrc /app
+COPY .prettierignore /app
 COPY tsconfig.json /app
-#COPY . /app
+COPY config-overrides.js /app
+
 WORKDIR /app
+
 RUN ls
-RUN npm install --legacy-peer-deps
+RUN npm ci --legacy-peer-deps
 
 COPY ./docker-entrypoint.sh /
 RUN chmod +x /docker-entrypoint.sh
@@ -19,7 +22,6 @@ RUN sh /docker-entrypoint.sh
 RUN npm run build
 
 FROM nginx:1.19.0
-#copies React to the container directory
 # Set working directory to nginx resources directory
 WORKDIR /usr/share/nginx/html
 # Remove default nginx static resources


### PR DESCRIPTION
The bug was introduced in #123.