### PR TITLE
feat(automation): rebase instance development branch if possible

### DIFF
--- a/.github/workflows/rebase_dev.yml
+++ b/.github/workflows/rebase_dev.yml
@@ -1,0 +1,14 @@
+name: Rebase instance development branch
+on:
+  push:
+    branches: [dev]
+
+jobs:
+  rebase:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: peter-evans/rebase@v2
+        with:
+          base: dev
+          include-labels: |
+            instance-development-branch


### PR DESCRIPTION
This is an automation feature to help reduce differences with the `dev` branch as much as possible.

The idea is to keep an open (__Draft__) PR with the `instance-development-branch` label for each instances at all time :
- if the dev branch is updated, the __instance branch__ is automatically updated
- when you want it merged, remove the __Draft__ status.

We will probably need to give this more thoughts... but for now we probably need to :
- reopen the same __Draft__ PR right after it was merged...

We might be playing with tags next... have you already ?