### PR TITLE
fix: configure `redux-logger` to log in development

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,6 @@
         "react-virtualized": "^9.22.3",
         "redux": "^4.0.5",
         "redux-devtools-extension": "^2.13.9",
-        "redux-logger": "^3.0.6",
         "redux-thunk": "^2.3.0",
         "styled-components": "^5.0.1",
         "styled-system": "^5.1.5",
@@ -53,6 +52,7 @@
       },
       "devDependencies": {
         "@types/redux-actions": "^2.6.2",
+        "@types/redux-logger": "^3.0.9",
         "@types/styled-components": "^5.1.25",
         "@types/webpack-env": "^1.16.3",
         "eslint-config-prettier": "^8.5.0",
@@ -62,7 +62,8 @@
         "husky": "^8.0.1",
         "lint-staged": "^13.0.3",
         "prettier": "^2.7.1",
-        "react-error-overlay": "^6.0.9"
+        "react-error-overlay": "^6.0.9",
+        "redux-logger": "^3.0.6"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -4389,6 +4390,15 @@
       "integrity": "sha512-TvcINy8rWFANcpc3EiEQX9Yv3owM3d3KIrqr2ryUIOhYIYzXA/bhDZeGSSSuai62iVR2qMZUgz9tQ5kr0Kl+Tg==",
       "dev": true
     },
+    "node_modules/@types/redux-logger": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/redux-logger/-/redux-logger-3.0.9.tgz",
+      "integrity": "sha512-cwYhVbYNgH01aepeMwhd0ABX6fhVB2rcQ9m80u8Fl50ZODhsZ8RhQArnLTkE7/Zrfq4Sz/taNoF7DQy9pCZSKg==",
+      "dev": true,
+      "dependencies": {
+        "redux": "^4.0.0"
+      }
+    },
     "node_modules/@types/resolve": {
       "version": "1.17.1",
       "license": "MIT",
@@ -7458,6 +7468,7 @@
     },
     "node_modules/deep-diff": {
       "version": "0.3.8",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/deep-equal": {
@@ -16503,7 +16514,9 @@
     },
     "node_modules/redux-logger": {
       "version": "3.0.6",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/redux-logger/-/redux-logger-3.0.6.tgz",
+      "integrity": "sha512-JoCIok7bg/XpqA1JqCqXFypuqBbQzGQySrhFzewB7ThcnysTO30l4VCst86AuB9T9tuT03MAA56Jw2PNhRSNCg==",
+      "dev": true,
       "dependencies": {
         "deep-diff": "^0.3.5"
       }
@@ -22835,6 +22848,15 @@
       "integrity": "sha512-TvcINy8rWFANcpc3EiEQX9Yv3owM3d3KIrqr2ryUIOhYIYzXA/bhDZeGSSSuai62iVR2qMZUgz9tQ5kr0Kl+Tg==",
       "dev": true
     },
+    "@types/redux-logger": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/redux-logger/-/redux-logger-3.0.9.tgz",
+      "integrity": "sha512-cwYhVbYNgH01aepeMwhd0ABX6fhVB2rcQ9m80u8Fl50ZODhsZ8RhQArnLTkE7/Zrfq4Sz/taNoF7DQy9pCZSKg==",
+      "dev": true,
+      "requires": {
+        "redux": "^4.0.0"
+      }
+    },
     "@types/resolve": {
       "version": "1.17.1",
       "requires": {
@@ -24785,7 +24807,8 @@
       "version": "0.7.0"
     },
     "deep-diff": {
-      "version": "0.3.8"
+      "version": "0.3.8",
+      "dev": true
     },
     "deep-equal": {
       "version": "1.1.1",
@@ -30244,6 +30267,9 @@
     },
     "redux-logger": {
       "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/redux-logger/-/redux-logger-3.0.6.tgz",
+      "integrity": "sha512-JoCIok7bg/XpqA1JqCqXFypuqBbQzGQySrhFzewB7ThcnysTO30l4VCst86AuB9T9tuT03MAA56Jw2PNhRSNCg==",
+      "dev": true,
       "requires": {
         "deep-diff": "^0.3.5"
       }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "react-virtualized": "^9.22.3",
     "redux": "^4.0.5",
     "redux-devtools-extension": "^2.13.9",
-    "redux-logger": "^3.0.6",
     "redux-thunk": "^2.3.0",
     "styled-components": "^5.0.1",
     "styled-system": "^5.1.5",
@@ -48,6 +47,7 @@
   },
   "devDependencies": {
     "@types/redux-actions": "^2.6.2",
+    "@types/redux-logger": "^3.0.9",
     "@types/styled-components": "^5.1.25",
     "@types/webpack-env": "^1.16.3",
     "eslint-config-prettier": "^8.5.0",
@@ -57,7 +57,8 @@
     "husky": "^8.0.1",
     "lint-staged": "^13.0.3",
     "prettier": "^2.7.1",
-    "react-error-overlay": "^6.0.9"
+    "react-error-overlay": "^6.0.9",
+    "redux-logger": "^3.0.6"
   },
   "scripts": {
     "start": "react-app-rewired start",

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -2,7 +2,6 @@ import { createStore, combineReducers, applyMiddleware, compose } from 'redux';
 import { composeWithDevTools } from 'redux-devtools-extension';
 import { enhanceReduxMiddleware } from 'erasme-kepler.gl';
 import { taskMiddleware } from 'react-palm/tasks';
-import { logger } from 'redux-logger';
 import thunk from 'redux-thunk';
 import keplerGlReducer from './keplerGl';
 import appReducer from './app';
@@ -22,28 +21,28 @@ const rootReducer = combineReducers({
 export type RootState = ReturnType<typeof rootReducer>;
 
 const middlewares = enhanceReduxMiddleware([thunk, taskMiddleware]);
-const enhancers = [applyMiddleware(...middlewares)];
 
-// Add redux devtools
+const actionsBlacklist = [
+  '@@kepler.gl/MOUSE_MOVE',
+  '@@kepler.gl/UPDATE_MAP',
+  '@@kepler.gl/LAYER_HOVER',
+];
 
 const composeEnhancers = composeWithDevTools({
-  actionsBlacklist: ['@@kepler.gl/MOUSE_MOVE', '@@kepler.gl/UPDATE_MAP', '@@kepler.gl/LAYER_HOVER'],
+  actionsBlacklist,
 });
-/**
- * comment out code below to enable Redux Devtools
- */
-// if (window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) {
-//   composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
-//     actionsBlacklist: [
-//       '@@kepler.gl/MOUSE_MOVE',
-//       '@@kepler.gl/UPDATE_MAP',
-//       '@@kepler.gl/LAYER_HOVER',
-//     ],
-//   });
-// }
 
 if (process.env.NODE_ENV === 'development') {
-  middlewares.push(logger);
+  const { createLogger } = require(`redux-logger`);
+
+  middlewares.push(
+    createLogger({
+      predicate: (getState, { type }) => !actionsBlacklist.includes(type),
+      collapsed: (getState, action, { error }) => !error,
+    }),
+  );
 }
+
+const enhancers = [applyMiddleware(...middlewares)];
 
 export default createStore(rootReducer, initialState, composeEnhancers(...enhancers));


### PR DESCRIPTION
It wasn't logging anything since it was pushed to middleware array after they were applied...

You may still use `redux-devtools`, but you probably won't need it anymore and you may disable your browser extension.

The same blacklist as `redux-devtools` is used for `redux-logger`.