### PR TITLE
fix: failing getHoverInfoLayer selector

### DIFF
--- a/src/store/keplerGl.ts
+++ b/src/store/keplerGl.ts
@@ -39,7 +39,7 @@ export const getFilters = (state) => state.keplerGl.map?.visState?.filters ?? []
 export const getFilterById = (filterId: string) => (state) =>
   state.keplerGl.map.visState.filters[filterId];
 export const getHoverInfo = (state) => state.keplerGl.map?.visState?.hoverInfo;
-export const getHoverInfoLayer = (state) => getHoverInfo(state).layer ?? null;
+export const getHoverInfoLayer = (state) => getHoverInfo(state)?.layer ?? null;
 export const getClicked = (state) => state.keplerGl.map?.visState?.clicked ?? null;
 
 export default keplerGl;


### PR DESCRIPTION
Fix a bug I previously introduced while refactoring a few selectors, sorry for that.