### PR TITLE
121 after docker build update env var

### DIFF
--- a/.github/workflows/build-front.yml
+++ b/.github/workflows/build-front.yml
@@ -1,4 +1,4 @@
-name: build-industries-dev
+name: build-front-datatlas
 on:
   push:
     branches:
@@ -25,5 +25,5 @@ jobs:
         with:
           push: true
           repository:  
-          tags: erasme/datatlas-industries:dev, erasme/datatlas-industries:${{ github.sha }}
+          tags: erasme/datatlas-front:dev, erasme/datatlas-front:${{ github.sha }}
 

--- a/.github/workflows/build-front.yml
+++ b/.github/workflows/build-front.yml
@@ -1,0 +1,29 @@
+name: build-industries-dev
+on:
+  push:
+    branches:
+      - 'dev'
+  workflow_dispatch:
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Push to Docker Hub
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          repository:  
+          tags: erasme/datatlas-industries:dev, erasme/datatlas-industries:${{ github.sha }}
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,5 +31,9 @@ COPY --from=prod /app/build .
 
 EXPOSE 80
 
+COPY ./entrypoint.sh ./
+
+COPY ./nginx.conf /etc/nginx/conf.d/default.conf
+
 # Containers run nginx with global directives and daemon off
-ENTRYPOINT ["nginx", "-g", "daemon off;"]
+ENTRYPOINT ["sh", "entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,4 +16,4 @@ services:
     #command: npm start
     stdin_open: true
     environment:
-      - REACT_APP_BACKEND_URL='http://localhost:8558'
+      - REACT_APP_BACKEND_URL=http://localhost:8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,15 +3,17 @@ services:
   datagora_datatlas_front:
     build:
       context: .
-      dockerfile: Dockerfile.dev
+      dockerfile: Dockerfile
       #target: dev
     restart: always
     ports:
-      - 0.0.0.0:3000:3000
-    volumes:
-      - ./src:/app/src
-      - ./public:/app/public
-      - ./.env:/app/.env
-
-    command: npm start
+      - 80:80
+    #volumes:
+      #- ./src:/app/src
+      #- ./public:/app/public
+      #- ./.env:/app/.env
+      #- ./test:/usr/share/nginx/html/static/js
+    #command: npm start
     stdin_open: true
+    environment:
+      - REACT_APP_BACKEND_URL='http://localhost:8558'

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
 #set -e
 
-
 echo "Writing env var into file "
 #echo $REACT_APP_BACKEND_URL
-echo "REACT_APP_BACKEND_URL='"http://localhost:3000"'" > .env 
+echo "REACT_APP_BACKEND_URL=localhost:3000" > .env 
 
 
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
-set -e
+#set -e
+
 
 echo "Writing env var into file "
-echo $REACT_APP_BACKEND_URL
-echo "REACT_APP_BACKEND_URL='"$REACT_APP_BACKEND_URL"'" > .env 
+#echo $REACT_APP_BACKEND_URL
+echo "REACT_APP_BACKEND_URL='"http://localhost:3000"'" > .env 
 
 
 exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,6 @@
+# Escape / with \/ for sed ex http://localhost:3000 -> http:\/\/localhost:3000
+REACT_APP_BACKEND_URL=$(echo $REACT_APP_BACKEND_URL | sed 's/\//\\\//g')
+
+# find in static/js and replace the string localhost:3000 with REACT_APP_BACKEND_URL
+sed -i "s/localhost:3000/$REACT_APP_BACKEND_URL/g" static/js/*.js
+nginx -g 'daemon off;'

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,12 @@
+server {
+  listen 80;
+  
+  location / {
+    root /usr/share/nginx/html;
+    index index.html index.htm;
+    try_files $uri $uri/ /index.html =404;
+    proxy_set_header  Host $http_host;
+  }
+  
+  include /etc/nginx/extra-conf.d/*.conf;
+}


### PR DESCRIPTION
Added and entrypoint.sh who replaces all `REACT_APP_BACKEND_URL` vars after npm build with Exported `REACT_APP_BACKEND_URL` env var

Allowing to not have to use specific builds for the front in the future (ex : datatalas-front:dev-industries )
The back url can now be declared at image deployment time with the variable `REACT_APP_BACKEND_URL=https://backurl`

Added a github file ci `build-front.yml` which should be the only file in the `.github/worflows` folder at maturity (except the lint ci files)